### PR TITLE
Allow window size to be configured

### DIFF
--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -5,10 +5,13 @@ require "puma"
 require "selenium-webdriver"
 
 module GovukTest
-  def self.configure
+  def self.configure(options = {})
+    chrome_options = %w(headless disable-gpu)
+    chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
+
     Capybara.register_driver :headless_chrome do |app|
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-        chromeOptions: { args: %w(headless disable-gpu) }
+        chromeOptions: { args: chrome_options }
       )
 
       Capybara::Selenium::Driver.new(

--- a/spec/govuk_test_spec.rb
+++ b/spec/govuk_test_spec.rb
@@ -1,0 +1,31 @@
+require 'govuk_test'
+
+RSpec.describe GovukTest do
+  let(:app) { double(:app) }
+  let(:default_args) { %w(headless disable-gpu) }
+
+  before do
+    allow(Capybara).to receive(:register_driver).with(:headless_chrome).and_yield(app)
+  end
+
+  context ".configure without options" do
+    it "uses default options" do
+      expect(Selenium::WebDriver::Remote::Capabilities).to receive(:chrome)
+        .with(chromeOptions: { args: default_args })
+
+      GovukTest.configure
+    end
+  end
+
+  context ".configure with options" do
+    let(:window_size) { "1366,768" }
+    let(:expected_args) { default_args << "--window-size=#{window_size}" }
+
+    it "appends the :window_size option to default options" do
+      expect(Selenium::WebDriver::Remote::Capabilities).to receive(:chrome)
+        .with(chromeOptions: { args: expected_args })
+
+      GovukTest.configure(window_size: window_size)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

This chrome option is useful for features which rely on a specific screen size. 