### PR TITLE
Require chromedriver-helper explictly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Explicitly require the `chromedriver-helper` Gem to fix the path to the binary.
+
 ## 0.2.0
 
 * Allow passing options to GovukTest.configure. Currently only `window_size` is supported. This is

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -2,6 +2,7 @@ require "govuk_test/version"
 
 require "capybara"
 require "puma"
+require "chromedriver-helper"
 require "selenium-webdriver"
 
 module GovukTest


### PR DESCRIPTION
Since [version 2.0.0 of chromedriver-helper](https://github.com/flavorjones/chromedriver-helper/pull/58), it renamed the binary from chromedriver to chromedriver-helper to avoid conflicts with the system binary.

Because of this we need to require this Gem explicitly which sets up the necessary Selenium configuration to allow it to use the new chromedriver-helper file.