### PR TITLE
Revert "Don't force use of chromedriver-helper"

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "capybara"
   spec.add_dependency "chromedriver-helper"
-  spec.add_dependency "ptools"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver"
 

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -1,22 +1,14 @@
 require "govuk_test/version"
 
 require "capybara"
-require "ptools"
 require "puma"
+require "chromedriver-helper"
 require "selenium-webdriver"
 
 module GovukTest
   def self.configure(options = {})
     chrome_options = %w(headless disable-gpu)
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
-
-    chromedriver_from_path = File.which("chromedriver")
-    if chromedriver_from_path
-      # Use the installed chromedriver, rather than chromedriver-helper
-      Selenium::WebDriver::Chrome.driver_path = chromedriver_from_path
-    else
-      require 'chromedriver-helper'
-    end
 
     Capybara.register_driver :headless_chrome do |app|
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
Reverts alphagov/govuk_test#7

This seems to be breaking apps in CI and causing problems. As @cbaines doesn't have time to look at it now it seems to make most sense to revert and release without the issue so that devs don't keep installing this gem and getting stuck.

Relevant PRs: https://github.com/alphagov/whitehall/pull/4492 & https://github.com/alphagov/content-publisher/pull/475