### PR TITLE
Revert "Revert "Don't force use of chromedriver-helper""

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "capybara"
   spec.add_dependency "chromedriver-helper"
+  spec.add_dependency "ptools"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver"
 

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -1,14 +1,22 @@
 require "govuk_test/version"
 
 require "capybara"
+require "ptools"
 require "puma"
-require "chromedriver-helper"
 require "selenium-webdriver"
 
 module GovukTest
   def self.configure(options = {})
     chrome_options = %w(headless disable-gpu)
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
+
+    chromedriver_from_path = File.which("chromedriver")
+    if chromedriver_from_path
+      # Use the installed chromedriver, rather than chromedriver-helper
+      Selenium::WebDriver::Chrome.driver_path = chromedriver_from_path
+    else
+      require 'chromedriver-helper'
+    end
 
     Capybara.register_driver :headless_chrome do |app|
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
This reverts commit c42c2ac4214cd03360ac7b7c986fc49d99c8a95a.

This was reverted as installing older versions of the
chromedriver-helper gem caused problems. Unfortunately, the wraith gem
has an unnecessarily strict dependency on the old version of the gem.

I was waiting until wraith was updated to fix this, but I think
service-manual-frontend is unnecessarily installing wraith on the CI
environment, which is triggering this issue. Therefore, just avoiding
unnecessary installs of wraith should be enough to avoid the problems
previously encountered with this.