### PR TITLE
Bump the version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.0
+
+* Don't download chromedriver if it's already available.
+
 ## 0.3.1
 
 * Revert "Don't force use of chromedriver-helper" - which seems to break apps in CI

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
This is a repeat of the 0.3.0 release, in which the change was
reverted due to conflicts between older versions of the
chromedriver-helper gem being installed in the CI environment.

I believe the cause of this was the dependency the
service-manual-frontend has on wraith, that has a
strict (unnecessarily so) dependency on the older version of
chromedriver-helper.

This has now been changed, and the older version of
chromedriver-helper isn't appearing on the CI agents anymore.