### PR TITLE
Guard against older versions of the chromedriver-helper gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Guard against older versions of the chromedriver-helper gem being
+  installed when looking for a chromedriver executable.
+
 ## 0.4.0
 
 * Don't download chromedriver if it's already available.

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -11,7 +11,13 @@ module GovukTest
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
 
     chromedriver_from_path = File.which("chromedriver")
-    if chromedriver_from_path
+
+    # Check the size of the file, as older versions of the
+    # chromedriver-helper gem (pre version 2) installed a binary with
+    # the name "chromedriver" that doesn't work. The Rubygems
+    # generated chromedriver file is 590 bytes in size, but say bigger
+    # than 1000 just in case the file gets bigger.
+    if chromedriver_from_path && File.lstat(chromedriver_from_path).size > 1000
       # Use the installed chromedriver, rather than chromedriver-helper
       Selenium::WebDriver::Chrome.driver_path = chromedriver_from_path
     else


### PR DESCRIPTION
Unfortunately, we're still installing the older versions of the
chromedriver-helper gem due to an unnecessarily string dependency from
the wraith gem. So just bail and use chromedriver-helper if it looks
like we've found something too small to be a real chromedriver binary.