### PR TITLE
Support explicitly using the system chromedriver

### DIFF
--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -10,10 +10,9 @@ module GovukTest
     chrome_options = %w(headless disable-gpu)
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
 
-    chromedriver_from_path = File.which("chromedriver")
-    if chromedriver_from_path
+    if ENV['GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER']
       # Use the installed chromedriver, rather than chromedriver-helper
-      Selenium::WebDriver::Chrome.driver_path = chromedriver_from_path
+      Selenium::WebDriver::Chrome.driver_path = File.which("chromedriver")
     else
       require 'chromedriver-helper'
     end


### PR DESCRIPTION
Looking up `chromedriver` on the PATH is a good idea in principle, but
the reality of how other gems (like wraith) that depend on old
versions of the chromedriver-helper gem which also provide a
non-working version of this binary, combined by the lack of any
isolation between different applications on the GOV.UK CI system makes
this error prone.

Therefore, just allow toggling this behaviour on via an environment
variable.