### PR TITLE
Release version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.1
+
+* Avoid issues with older versions of the chromedriver-helper gem, by
+  only using chromedriver form the PATH if
+  GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER is set in the environment.
+
 ## 0.4.0
 
 * Don't download chromedriver if it's already available.

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
This addresses some issues with using the 0.4.0 release where version
1 of the chromedriver-helper gem is also present.