### PR TITLE
Silence Puma logs during spec suite

### DIFF
--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -30,5 +30,6 @@ module GovukTest
     end
 
     Capybara.javascript_driver = :headless_chrome
+    Capybara.server = :puma, { Silent: true }
   end
 end


### PR DESCRIPTION
This is to silence Puma logs and prevent it from writing
```
Puma starting in single mode...
* Version 3.10.0 (ruby 2.4.1-p111), codename: Russell's Teapot
* Min threads: 0, max threads: 1
* Environment: test
* Listening on tcp://0.0.0.0:36775
Use Ctrl-C to stop
```
while running the test suite.

See https://github.com/rspec/rspec-rails/issues/1897 for more context.