### PR TITLE
Release version 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.2
+
+* Silence Puma logs during spec suite.
+
 ## 0.4.1
 
 * Avoid issues with older versions of the chromedriver-helper gem, by

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
This is to silence Puma logs during spec suite. See https://github.com/alphagov/govuk_test/pull/16