### PR TITLE
Upgrade chromedriver helper to webdrivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Swap the deprecated chromedriver-helper gem for webdrivers gem
+
 ## 0.4.2
 
 * Silence Puma logs during spec suite.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Somewhere in your `spec_helper` put:
 GovukTest.configure
 ```
 
+>This will overwrite any Webmock disabled net connections in your application.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Somewhere in your `spec_helper` put:
 GovukTest.configure
 ```
 
->This will overwrite any Webmock disabled net connections in your application.
-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "capybara"
   spec.add_dependency "webdrivers"
-  spec.add_dependency "ptools"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver"
 

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara"
-  spec.add_dependency "chromedriver-helper"
+  spec.add_dependency "webdrivers"
   spec.add_dependency "ptools"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver"

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -11,10 +11,10 @@ module GovukTest
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
 
     if ENV['GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER']
-      # Use the installed chromedriver, rather than chromedriver-helper
+      # Use the installed chromedriver, rather than webdrivers
       Selenium::WebDriver::Chrome.driver_path = File.which("chromedriver")
     else
-      require 'chromedriver-helper'
+      require 'webdrivers'
     end
 
     Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
`chromedriver-helpers` is now deprecated and can be replaced with the better
supported `webdrivers`.

`webdrivers` causes [an issue](https://github.com/titusfortner/webdrivers/issues/4) with `webmock`. This Gem will now configure Webmock for consuming applications.

[Trello](https://trello.com/c/U20wbvEk/955-upgrade-govuktest-to-use-webdrivers)
