### PR TITLE
Remove chromedriver-helper and use system binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+* Remove the now-deprecated chromedriver-helper gem in favour of system binaries
+
 ## 0.4.2
 
 * Silence Puma logs during spec suite.

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara"
-  spec.add_dependency "chromedriver-helper"
   spec.add_dependency "ptools"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver"

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -10,13 +10,6 @@ module GovukTest
     chrome_options = %w(headless disable-gpu)
     chrome_options << "--window-size=#{options[:window_size]}" if options[:window_size]
 
-    if ENV['GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER']
-      # Use the installed chromedriver, rather than chromedriver-helper
-      Selenium::WebDriver::Chrome.driver_path = File.which("chromedriver")
-    else
-      require 'chromedriver-helper'
-    end
-
     Capybara.register_driver :headless_chrome do |app|
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
         chromeOptions: { args: chrome_options }


### PR DESCRIPTION
Previously we used the chromedriver-helper gem to automatically download
a suitable chromedriver binary for use with headless testing. This gem
is no longer maintained, and since work had already begun to start using
the system binary, it seems best to drop it altogether.

https://github.com/flavorjones/chromedriver-helper/issues/83

A system binary for chromedriver should already installed on all Jenkins
agents, but a Puppet gem is still needed to install it on all Dev VMs.