### PR TITLE
Allow `.configure` to accept extra chrome options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Allow `.configure` to accept extra chrome options
+
 ## 0.4.3
 
 * Swap the deprecated chromedriver-helper gem for webdrivers gem

--- a/README.md
+++ b/README.md
@@ -14,10 +14,25 @@ And then execute:
 
 ## Usage
 
-Somewhere in your `spec_helper` put:
+Somewhere in your `spec_helper`, `rails_helper`, or `spec/support/govuk_test.rb` put:
 
 ```rb
 GovukTest.configure
+```
+
+It's also possible to pass optional arguments `:chrome_options` and/or `:window_size `
+to `GovukTest.configure`:
+
+```rb
+GovukTest.configure(chrome_options: { some_key: "some value" })
+
+# or
+
+GovukTest.configure(window_size: "1366,768")
+
+# or
+
+GovukTest.configure(chrome_options: { some_key: "some value" }, window_size: "800,600")
 ```
 
 ## License

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -23,7 +23,7 @@ module GovukTest
 
     Capybara.register_driver :headless_chrome do |app|
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-        chromeOptions: { args: chrome_options }
+        chromeOptions: { args: chrome_options }.merge(options.fetch(:chrome_options, {}))
       )
 
       Capybara::Selenium::Driver.new(

--- a/spec/govuk_test_spec.rb
+++ b/spec/govuk_test_spec.rb
@@ -18,14 +18,25 @@ RSpec.describe GovukTest do
   end
 
   context ".configure with options" do
-    let(:window_size) { "1366,768" }
-    let(:expected_args) { default_args << "--window-size=#{window_size}" }
+    context "with :window_size" do
+      let(:window_size) { "1366,768" }
+      let(:expected_args) { default_args << "--window-size=#{window_size}" }
 
-    it "appends the :window_size option to default options" do
-      expect(Selenium::WebDriver::Remote::Capabilities).to receive(:chrome)
-        .with(chromeOptions: { args: expected_args })
+      it "appends the :window_size option to default options" do
+        expect(Selenium::WebDriver::Remote::Capabilities).to receive(:chrome)
+          .with(chromeOptions: { args: expected_args })
 
-      GovukTest.configure(window_size: window_size)
+        GovukTest.configure(window_size: window_size)
+      end
+    end
+
+    context "with :chrome_options" do
+      it "merges the :chrome_options option to the :chromeOptions" do
+        expect(Selenium::WebDriver::Remote::Capabilities).to receive(:chrome)
+          .with(chromeOptions: { args: default_args, some_key: 'some value' })
+
+        GovukTest.configure(chrome_options: { some_key: 'some value' })
+      end
     end
   end
 end


### PR DESCRIPTION
This is to be able to pass options like `chrome_options: { w3c: false }`

Trello card: https://trello.com/c/RNxnxVVy/1056-fix-chromedriver-issues-in-datagovukfind