### PR TITLE
Bump to version `0.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.5.0
+
+* No changes: new release for semantic versioning purposes (0.4.4 should have been 0.5.0)
+
 ## 0.4.4
 
 * Allow `.configure` to accept extra chrome options

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "0.4.4"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
The changes in https://github.com/alphagov/govuk_test/pull/21 are a new
feature so https://github.com/alphagov/govuk_test/pull/22 should have
bumped the gem to version `0.5.0`. Doing this now.

Trello card: 
https://trello.com/c/RNxnxVVy/1056-fix-chromedriver-issues-in-datagovukfind