### PR TITLE
Ensure version of webdrivers gem is at least 4

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara"
-  spec.add_dependency "webdrivers"
+  spec.add_dependency "webdrivers", "~> 4"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
 

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Previously we did not specify a version constraint for the webdrivers
gem, although we rely on the version in use being 4+.

Should fix: https://github.com/alphagov/content-publisher/pull/1381/files#diff-e79a60dc6b85309ae70a6ea8261eaf95R438