### PR TITLE
Add Brakeman as a dependency

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "webdrivers", ">= 4"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
+  spec.add_dependency "brakeman", "~> 4.6"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This will allow us to use the version of Brakeman specified in the `Gemfile.lock` for the project rather than the version manually installed onto the CI or our local machines. Currently we can't do this because most of our apps don't have Brakeman listed as a dependency.

This will make it easier to run Brakeman locally when debugging security issues that get flagged by the tool, but should also make the CI run more reliable as all we need to do is run `bundle exec brakeman` which is easier to understand and less complex than the current method [(of manually installing Brakeman first into a directory and running it from there)](https://github.com/alphagov/govuk-jenkinslib/blob/0f29f578e40b68059872137aa9645a901d2aecdb/vars/govuk.groovy#L289-L309).

I'm also hoping this will fix an intermittent problem we have where sometimes Brakeman will fail to run correctly in CI as it hasn't been installed properly.

[Trello Card](https://trello.com/c/qocdsaLD/1367-look-into-why-brakeman-occasionally-fails-on-test-runs)