### PR TITLE
Allow specifying chrome to run without a sandbox and re-usable chrome options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ## Unreleased
 
+* BREAKING: `.configure` no longer accepts options. If you need to modify the
+  headless_chrome selenium driver you can re-register the driver with
+  `Capybara.register_driver`.
+* `GovukTest.headless_chrome_selenium_options` added to allow accessing the
+  headless Chrome selenium options for other contexts (such as configuring
+  Jasmine).
 * `GOVUK_TEST_CHROME_NO_SANDBOX` can be set to default Chrome to be running
   with the `--no-sandbox` argument.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* `GOVUK_TEST_CHROME_NO_SANDBOX` can be set to default Chrome to be running
+  with the `--no-sandbox` argument.
+
 ## 1.0.3
 
 * Add Brakeman as a dependency.

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "brakeman", "~> 4.6"
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -16,6 +16,7 @@ module GovukTest
   def self.configure(chrome_options: nil)
     chrome_options ||= Selenium::WebDriver::Chrome::Options.new
     chrome_options.headless!
+    chrome_options.add_argument("--no-sandbox") if ENV["GOVUK_TEST_CHROME_NO_SANDBOX"]
 
     Capybara.register_driver :headless_chrome do |app|
       Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -13,16 +13,21 @@ unless ENV["GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER"]
 end
 
 module GovukTest
-  def self.configure(chrome_options: nil)
-    chrome_options ||= Selenium::WebDriver::Chrome::Options.new
-    chrome_options.headless!
-    chrome_options.add_argument("--no-sandbox") if ENV["GOVUK_TEST_CHROME_NO_SANDBOX"]
-
+  def self.configure
     Capybara.register_driver :headless_chrome do |app|
-      Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
+      Capybara::Selenium::Driver.new(app,
+                                     browser: :chrome,
+                                     options: headless_chrome_selenium_options)
     end
 
     Capybara.javascript_driver = :headless_chrome
     Capybara.server = :puma, { Silent: true }
+  end
+
+  def self.headless_chrome_selenium_options
+    Selenium::WebDriver::Chrome::Options.new.tap do |options|
+      options.headless!
+      options.add_argument("--no-sandbox") if ENV["GOVUK_TEST_CHROME_NO_SANDBOX"]
+    end
   end
 end

--- a/spec/govuk_test_spec.rb
+++ b/spec/govuk_test_spec.rb
@@ -10,28 +10,30 @@ RSpec.describe GovukTest do
         .to(:headless_chrome)
     end
 
-    it "can specify chrome to run in no sandbox mode" do
+    it "uses .headless_chrome_selenium_options to set default options" do
       GovukTest.configure
       driver = Capybara.drivers[:headless_chrome].call
-      expect(driver.options[:options].args).not_to include("--no-sandbox")
+      expect(driver.options[:options].args)
+        .to eq(GovukTest.headless_chrome_selenium_options.args)
+    end
+  end
 
-      ClimateControl.modify(GOVUK_TEST_CHROME_NO_SANDBOX: "true") do
-        GovukTest.configure
-        driver = Capybara.drivers[:headless_chrome].call
-        expect(driver.options[:options].args).to include("--no-sandbox")
-      end
+  describe ".headless_chrome_selenium_options" do
+    it "returns an instance of Selenium::WebDriver::Chrome::Options set as headless" do
+      options = GovukTest.headless_chrome_selenium_options
+
+      expect(options).to be_instance_of(Selenium::WebDriver::Chrome::Options)
+      expect(options.args).to include("--headless")
     end
 
-    context "with chrome_options" do
-      it "can set the options for the headless_chrome driver" do
-        chrome_options = Selenium::WebDriver::Chrome::Options.new
-        chrome_options.add_option(:window_size, "1366,768")
+    it "can be configured with an environment variable to run in no-sandbox" do
+      expect(GovukTest.headless_chrome_selenium_options.args)
+        .not_to include("--no-sandbox")
 
-        GovukTest.configure(chrome_options: chrome_options)
-
-        driver = Capybara.drivers[:headless_chrome].call
-
-        expect(driver.options[:options]).to be(chrome_options)
+      ClimateControl.modify(GOVUK_TEST_CHROME_NO_SANDBOX: "1") do
+        GovukTest.configure
+        expect(GovukTest.headless_chrome_selenium_options.args)
+          .to include("--no-sandbox")
       end
     end
   end

--- a/spec/govuk_test_spec.rb
+++ b/spec/govuk_test_spec.rb
@@ -1,4 +1,5 @@
-require 'govuk_test'
+require "govuk_test"
+require "climate_control"
 
 RSpec.describe GovukTest do
   describe ".configure" do
@@ -7,6 +8,18 @@ RSpec.describe GovukTest do
       expect { GovukTest.configure }
         .to change { Capybara.javascript_driver }
         .to(:headless_chrome)
+    end
+
+    it "can specify chrome to run in no sandbox mode" do
+      GovukTest.configure
+      driver = Capybara.drivers[:headless_chrome].call
+      expect(driver.options[:options].args).not_to include("--no-sandbox")
+
+      ClimateControl.modify(GOVUK_TEST_CHROME_NO_SANDBOX: "true") do
+        GovukTest.configure
+        driver = Capybara.drivers[:headless_chrome].call
+        expect(driver.options[:options].args).to include("--no-sandbox")
+      end
     end
 
     context "with chrome_options" do


### PR DESCRIPTION
Trello: https://trello.com/c/PlDX9ps8/180-run-govuk-docker-containers-as-root-to-allow-application-specific-mounts

We have an [issue configuring Docker volumes in govuk-docker](https://github.com/docker/compose/issues/3270) when containers aren't running as root, we have configured our [Ruby containers to run as a non-root user](https://github.com/alphagov/govuk-docker/blob/eb32fd471843fdc0569137566ccf7467a0ac0406/Dockerfile.govuk-base#L40-L42) so that we can run Google Chrome for browser tests. To resolve these problems this allows an env var `GOVUK_TEST_CHROME_NO_SANDBOX` to specify no-sandbox as a Chrome argument to allow running the tests as root.

This also provides a public method of `.headless_chrome_selenium_options` which can be used to access the base arguments for Google Chrome (including whether or not there is a sandbox). This has been provided so we don't have to re-define these arguments when Chrome is used in other contexts (such as Jasmine tests).

(lots) more info in the commits