### PR TITLE
Release version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 2.0.0
 
 * BREAKING: `.configure` no longer accepts options. If you need to modify the
   headless_chrome selenium driver you can re-register the driver with

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "1.0.3"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
* BREAKING: `.configure` no longer accepts options. If you need to modify the
  headless_chrome selenium driver you can re-register the driver with
  `Capybara.register_driver`.
* `GovukTest.headless_chrome_selenium_options` added to allow accessing the
  headless Chrome selenium options for other contexts (such as configuring
  Jasmine).
* `GOVUK_TEST_CHROME_NO_SANDBOX` can be set to default Chrome to be running
  with the `--no-sandbox` argument.