### PR TITLE
Add pact test branch verify rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Add pact test branch verify rake task
 * Add Railtie to load rake tasks
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Add Railtie to load rake tasks
+
 ## 2.0.0
 
 * BREAKING: `.configure` no longer accepts options. If you need to modify the

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -1,3 +1,4 @@
+require "govuk_test/railtie" if defined?(Rails)
 require "govuk_test/version"
 
 require "capybara"

--- a/lib/govuk_test/railtie.rb
+++ b/lib/govuk_test/railtie.rb
@@ -1,0 +1,9 @@
+require "govuk_test"
+
+module GovukTest
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      Dir[File.expand_path('../tasks/**/*.rake', File.dirname(__FILE__))].each { |f| load f }
+    end
+  end
+end

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,0 +1,19 @@
+require "govuk_test"
+
+require "pact/tasks"
+require "pact/tasks/task_helper"
+
+namespace :pact do
+  desc "Verify the API contract for a specific branch"
+  task "verify:branch", [:branch_name] => :environment do |t, args|
+    abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+  
+    pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+  
+    ClimateControl.modify(GDS_API_ADAPTERS_PACT_VERSION: pact_version) do
+      Pact::TaskHelper.handle_verification_failure do
+        Pact::TaskHelper.execute_pact_verify
+      end
+    end
+  end
+end


### PR DESCRIPTION
This identical rake task is used in a number of applications. By including it in this gem, we won't have duplication across multiple applications.

Once the gem version has been increased in the respective application, we can remove the task from:
- https://github.com/alphagov/account-api/blob/674e761d03ea95f08ccb2c0b974d4cfa5e2eca85/lib/tasks/pact.rake
- https://github.com/alphagov/content-store/blob/41c3297fec1c27200814e2e763f5a6fa0c7c500d/lib/tasks/pact.rake
- https://github.com/alphagov/collections/blob/8ce9c37c935c707782fea160f6acab15ce82ec02/lib/tasks/pact.rake
- https://github.com/alphagov/frontend/blob/82765bd808294f891b77972143bafb5ecc02e001/lib/tasks/pact.rake
- https://github.com/alphagov/publishing-api/blob/22eae96cb9c8b46334b46b7e2167a69d23059d13/lib/tasks/pact.rake

Trello card: https://trello.com/c/rnfUFP5o