### PR TITLE
Add pact to gemspec dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 2.1.1
+
+* Add `pact` as a dependency
+
 ## 2.1.0
 
 * Add pact test branch verify rake task

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "brakeman", "~> 4.6"
   spec.add_dependency "capybara"
-  spec.add_dependency "webdrivers", ">= 4"
+  spec.add_dependency "pact"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
-  spec.add_dependency "brakeman", "~> 4.6"
-  spec.add_dependency "pact"
+  spec.add_dependency "webdrivers", ">= 4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
   spec.add_dependency "brakeman", "~> 4.6"
+  spec.add_dependency "pact"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
A rake task was added in 501d7ad which includes "pact/tasks", but it was not added as a dependency.

Also bumps the version to 2.1.1, as the current release breaks our Jenkins pipeline for non-pact tested apps.

Trello card: https://trello.com/c/rnfUFP5o