### PR TITLE
Mark ClimateControl as a dependency (rather than dev dependency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 2.1.2
+
+* Mark `climate_control` as a dependency (rather than dev dependency)
+
 ## 2.1.1
 
 * Add `pact` as a dependency

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "brakeman", "~> 4.6"
   spec.add_dependency "capybara"
+  spec.add_dependency "climate_control"
   spec.add_dependency "pact"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
   spec.add_dependency "webdrivers", ">= 4"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
A rake task was added in 501d7ad which relies on the ClimateControl gem. If downstream apps attempt to run the task and don't have ClimateControl installed to their own projects, it will fail:
https://github.com/alphagov/govuk_test/pull/35#issuecomment-814096274

It should be possible to remove the ClimateControl dependency altogether by refactoring the rake task, but that can be done in a later PR.

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days