### PR TITLE
Remove ClimateControl and Pact dependencies from govuk_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 2.1.3
+
+* Remove `pact` and `climate_control` as direct dependencies
+
 ## 2.1.2
 
 * Mark `climate_control` as a dependency (rather than dev dependency)

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "brakeman", "~> 4.6"
   spec.add_dependency "capybara"
-  spec.add_dependency "pact"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
   spec.add_dependency "webdrivers", ">= 4"

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "brakeman", "~> 4.6"
   spec.add_dependency "capybara"
-  spec.add_dependency "climate_control"
   spec.add_dependency "pact"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
   spec.add_dependency "webdrivers", ">= 4"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,11 +1,14 @@
 require "govuk_test"
 
-require "pact/tasks"
-require "pact/tasks/task_helper"
-
 namespace :pact do
   desc "Verify the API contract for a specific branch"
   task "verify:branch", [:branch_name] => :environment do |t, args|
+    begin
+      require "pact/tasks"
+      require "pact/tasks/task_helper"
+    rescue LoadError
+      abort "Pact must be added as a dependency in the downstream app."
+    end
     abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
   
     pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -9,11 +9,9 @@ namespace :pact do
     abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
   
     pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
-  
-    ClimateControl.modify(GDS_API_ADAPTERS_PACT_VERSION: pact_version) do
-      Pact::TaskHelper.handle_verification_failure do
-        Pact::TaskHelper.execute_pact_verify
-      end
+    ENV["GDS_API_ADAPTERS_PACT_VERSION"] = pact_version
+    Pact::TaskHelper.handle_verification_failure do
+      Pact::TaskHelper.execute_pact_verify
     end
   end
 end


### PR DESCRIPTION
This PR removes ClimateControl and Pact dependencies (although ClimateControl remains as a dev dependency, as it is used by some internal tests).

I've manually tested against Frontend's branch in https://github.com/alphagov/frontend/pull/2698, by appending `, path: "../govuk_test"` to `gem "govuk_test"` in its Gemfile, running bundle install and then running:

```
govuk-docker-run env PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json" bundle exec rake pact:verify:branch[master]
```

This PR addresses https://github.com/alphagov/govuk_test/pull/37#issuecomment-815983176.

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days