### PR TITLE
Consolidate Pact host ports into GovukTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 2.2.0
+
+* Expose Pact host ports via `GovukTest::Pact`
+
 ## 2.1.2
 
 * Mark `climate_control` as a dependency (rather than dev dependency)

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -1,3 +1,4 @@
+require "govuk_test/pact"
 require "govuk_test/railtie" if defined?(Rails)
 require "govuk_test/version"
 

--- a/lib/govuk_test/pact.rb
+++ b/lib/govuk_test/pact.rb
@@ -1,0 +1,20 @@
+module GovukTest
+  class Pact
+    PACT_APP_PORTS = {
+      publishing_api: 3001,
+      organisation_api: 3002,
+      bank_holidays_api: 3003,
+      account_api: 3004,
+    }
+
+    def self.host(api)
+      "http://localhost:#{host_port(api)}"
+    end
+
+    def self.host_port(api)
+      raise "No Pact configuration found for API #{api}" unless PACT_APP_PORTS[api]
+
+      PACT_APP_PORTS[api]
+    end
+  end
+end

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end

--- a/spec/govuk_test/pact_spec.rb
+++ b/spec/govuk_test/pact_spec.rb
@@ -1,0 +1,29 @@
+require "govuk_test"
+
+RSpec.describe GovukTest::Pact do
+  describe ".host_port" do
+    it "retrieves the full Pact host of the app" do
+      expect(GovukTest::Pact.host_port(:publishing_api)).to eq(3001)
+      expect(GovukTest::Pact.host_port(:organisation_api)).to eq(3002)
+      expect(GovukTest::Pact.host_port(:bank_holidays_api)).to eq(3003)
+      expect(GovukTest::Pact.host_port(:account_api)).to eq(3004)
+    end
+
+    it "raises an error if the app isn't recognised" do
+      expect { GovukTest::Pact.host_port(:made_up_api) }
+        .to raise_error("No Pact configuration found for API made_up_api")
+    end
+  end
+
+  describe ".host" do
+    it "retrieves the full Pact host of the app" do
+      expect(GovukTest::Pact.host(:organisation_api))
+        .to eq("http://localhost:3002")
+    end
+
+    it "raises an error if the app isn't recognised" do
+      expect { GovukTest::Pact.host(:made_up_api) }
+        .to raise_error("No Pact configuration found for API made_up_api")
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, we've had to keep the hosts in sync between
the provider and the consumer.

Provider: https://github.com/alphagov/frontend/blob/7e83b45609ccd3b93dc39454cd54c51673fd5aaf/test/service_consumers/pact_helper.rb#L19
Consumer: https://github.com/alphagov/gds-api-adapters/blob/c2944f00b8de45b5c78b195807c055367da71630/test/test_helpers/pact_helper.rb#L3

This is not a good pattern maintenance-wise. It is better to keep
this information in govuk_test, which becomes the single source of
truth for these ports & hostnames, and the values can then be
retrieved dynamically by GDS API Adapters and the Providers (e.g.
Frontend).

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days