### PR TITLE
Update brakeman to fix false positive warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 2.3.0
+
+* Update brakeman to fix false positive warning ([#41](https://github.com/alphagov/govuk_test/pull/41))
+
 ## 2.2.0
 
 * Remove pact test branch verify rake task

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "brakeman", "~> 4.6"
+  spec.add_dependency "brakeman", ">= 5.0.2"
   spec.add_dependency "capybara"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
We recently came across a [strange warning][0] in a `frontend` build:

```
== Warnings ==

Confidence: High
Category: Cross-Site Scripting
Check: SanitizeMethods
Message: loofah gem 2.10.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1
File: Gemfile.lock
Line: 187
```

Version 2.10.0 is clearly more recent than 2.2.1. This came from how
brakeman was doing a check:
```
loofah_version and loofah_version < "2.2.1"
```
but in ruby `'2.10.0' < '2.2.1'` is true:
```
[2] pry(main)> '2.10.0' < '2.2.1'
=> true
```

This [has been fixed][1] in [version 5.0.2][2] so let's upgrade brakeman to
this new version.

[0]: https://ci.integration.publishing.service.gov.uk/job/frontend/job/update-rubocop/6/console
[1]: https://github.com/presidentbeef/brakeman/pull/1607/files
[2]: https://github.com/presidentbeef/brakeman/blob/main/CHANGES.md#502---2021-06-07