### PR TITLE
Stop using webdrivers gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 3.0.0
+
+* BREAKING: Remove dependency on `webdrivers` gem. It's now expected that ChromeDriver is present on the underlying operating system. ([#43](https://github.com/alphagov/govuk_test/pull/43))
+
 ## 2.3.0
 
 * Update brakeman to fix false positive warning ([#41](https://github.com/alphagov/govuk_test/pull/41))

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capybara"
   spec.add_dependency "puma"
   spec.add_dependency "selenium-webdriver", ">= 3.142"
-  spec.add_dependency "webdrivers", ">= 4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -4,14 +4,6 @@ require "capybara"
 require "puma"
 require "selenium-webdriver"
 
-unless ENV["GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER"]
-  require "webdrivers"
-
-  # This stop webdrivers doing a lazy check for new versions
-  # of chromedriver, which interferes with WebMock.disable_net_connect
-  Selenium::WebDriver::Chrome::Service.driver_path = Webdrivers::Chromedriver.update
-end
-
 module GovukTest
   def self.configure
     Capybara.register_driver :headless_chrome do |app|

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "2.3.0"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
We've traditionally used the gem [`webdrivers`][webdrivers] to automagically install ChromeDriver on the system at runtime, so that it's available for use by Capybara and headless Jasmine tests.

However this approach is beginning to cause us some problems because Google Chrome and ChromeDriver aren't currently available as Linux ARM binaries. This means that developers on Apple M1 MacBooks are unable to run tests when working in the [govuk-docker] development environment.

We've therefore made the decision to change how we install and use Chrome and its associated WebDriver. Instead of applications being responsible for installing ChromeDriver via this gem's use of `webdrivers`, we've made it the responsibility of the underlying operating system to provide a compatible browser and WebDriver.

In everyday use, this change should be unnoticeable because we've prepared our tooling ahead of time:
- govuk-docker now comes with ChromeDriver (see alphagov/govuk-docker#577)
- Jasmine CI workers also have ChromeDriver (see alphagov/govuk-puppet#11568)
- The GitHub Actions `ubuntu-latest` image has ChromeDriver pre-installed (see [the docs][ubuntu-latest])

However, if you're running tests in another environment (e.g. local development on bare metal), you'll need to make sure ChromeDriver is available. This is usually as simple as running:

```
$ brew install chromedriver
```

[webdrivers]: https://rubygems.org/gems/webdrivers
[govuk-docker]: https://github.com/alphagov/govuk-docker
[ubuntu-latest]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#browsers-and-drivers