### PR TITLE
Use capabilities rather than options to resolve deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* Resolve Selenium deprecation warning on options argument by requiring higher minimum versions ([#44](https://github.com/alphagov/govuk_test/pull/44))
+
 ## 3.0.0
 
 * BREAKING: Remove dependency on `webdrivers` gem. It's now expected that ChromeDriver is present on the underlying operating system. ([#43](https://github.com/alphagov/govuk_test/pull/43))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 3.0.1
 
 * Resolve Selenium deprecation warning on options argument by requiring higher minimum versions ([#44](https://github.com/alphagov/govuk_test/pull/44))
 

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "brakeman", ">= 5.0.2"
-  spec.add_dependency "capybara"
+  spec.add_dependency "capybara", ">= 3.36"
   spec.add_dependency "puma"
-  spec.add_dependency "selenium-webdriver", ">= 3.142"
+  spec.add_dependency "selenium-webdriver", ">= 4.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"

--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -9,7 +9,7 @@ module GovukTest
     Capybara.register_driver :headless_chrome do |app|
       Capybara::Selenium::Driver.new(app,
                                      browser: :chrome,
-                                     options: headless_chrome_selenium_options)
+                                     capabilities: headless_chrome_selenium_options)
     end
 
     Capybara.javascript_driver = :headless_chrome

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/spec/govuk_test_spec.rb
+++ b/spec/govuk_test_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GovukTest do
     it "uses .headless_chrome_selenium_options to set default options" do
       GovukTest.configure
       driver = Capybara.drivers[:headless_chrome].call
-      expect(driver.options[:options].args)
+      expect(driver.options[:capabilities].args)
         .to eq(GovukTest.headless_chrome_selenium_options.args)
     end
   end


### PR DESCRIPTION
Since selenium-webdriver version 4.0.0.alpha6 the options keyword
argument has been deprecated for capabilities.

To cater for this we have switched our keyword to use that and bumped
the minimum version of Capybara and Selenium Webdriver to be the minimum
version that these arguments will be supported for (to avoid any
conditionals as per Capybara [1]

This resolves https://github.com/alphagov/govuk_test/issues/42

[1]: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/registrations/drivers.rb#L21-L23