### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1, 3.2]
+        ruby: ['3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 2.7 reaches EOL on 31st March 2023.

https://trello.com/c/ynkZlvh8/3119-drop-ruby-27-support-from-gems-3