### PR TITLE
Fix failing main build

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -14,11 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 3.0"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -5,13 +5,14 @@ require "govuk_test/version"
 Gem::Specification.new do |spec|
   spec.name          = "govuk_test"
   spec.version       = GovukTest::VERSION
-  spec.authors     = ["GOV.UK Dev"]
-  spec.email       = ["govuk-dev@digital.cabinet-office.gov.uk"]
+  spec.authors       = ["GOV.UK Dev"]
+  spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 
   spec.summary       = "Test setup for GOV.UK"
   spec.description   = "Test configuration and dependencies for applications on GOV.UK"
   spec.homepage      = "https://github.com/alphagov/govuk_test"
   spec.license       = "MIT"
+
   spec.required_ruby_version = ">= 3.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin)/}) }

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 3.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]


### PR DESCRIPTION
The main merge for this repo is failing with an error:

```
(eval):19:in `expand_path': no implicit conversion of nil into String (TypeError)
from (eval):19:in `block in <main>'
from /opt/hostedtoolcache/Ruby/3.0.5/x64/lib/ruby/site_ruby/3.0.0/rubygems/specification.rb:2055:in `initialize'
from (eval):5:in `new'
from (eval):5:in `<main>'
from -e:1:in `eval'
from -e:1:in `<main>'
```

This was occurring because of the contextual command of changing
directory that fails when the gemspec is eval'd as part of pushing a gem
[1]. While the ultimate cause of this is the fragility of an eval
command (🤢) the simplest fix is the simplify the command.

[1]: https://github.com/alphagov/govuk-infrastructure/blob/bfc9e8b9549161b524b31b749050e5fc48f8d3f4/.github/workflows/publish-rubygem.yml#L61

This also has a couple of small amends to the gemspec.