### PR TITLE
Replace deprecated `headless!` option

### DIFF
--- a/lib/govuk_test.rb
+++ b/lib/govuk_test.rb
@@ -18,7 +18,7 @@ module GovukTest
 
   def self.headless_chrome_selenium_options
     Selenium::WebDriver::Chrome::Options.new.tap do |options|
-      options.headless!
+      options.add_argument("--headless")
       options.add_argument("--no-sandbox") if ENV["GOVUK_TEST_CHROME_NO_SANDBOX"]
     end
   end


### PR DESCRIPTION
[This Selenium blog post from 29 Jan 2023][1] explains that the `headless!` convenience method is being deprecated. There are now 2 headless modes in Chromium so we should use the arguments to browser options to define the mode we want.

The deprecation message reads:

> 2023-10-09 11:12:07 WARN Selenium [:headless] [DEPRECATION]
> `Options#headless!` is deprecated. Use
> `Options#add_argument('--headless=new')` instead.

Although it says to use `--headless=new`, I've chosen to switch to `--headless` in this commit as this retains the existing behaviour of `headless!`. You can verify this in the diff of the [commit that removes the deprecated `headless!` method][2].

[1]: https://www.selenium.dev/blog/2023/headless-is-going-away/
[2]: https://github.com/SeleniumHQ/selenium/commit/0fa6c3f327c1f61fe861d5c648224c4c23b8cb36