### PR TITLE
Revert "Pin `selenium-webdriver` to < 4.11"

### DIFF
--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "brakeman", ">= 5.0.2"
   spec.add_dependency "capybara", ">= 3.36"
   spec.add_dependency "puma"
-  spec.add_dependency "selenium-webdriver", ">= 4.0", "< 4.11"
+  spec.add_dependency "selenium-webdriver", ">= 4.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "climate_control"


### PR DESCRIPTION
Reverts alphagov/govuk_test#60

This should no longer be needed now that the deprecated call to `headless!` has been removed in #63 🤞 