### PR TITLE
Upgrade to govuk-dependabot-merger v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /tmp/
 
 Gemfile.lock
+
+# simplecov
+coverage/

--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,4 @@
-api_version: 1
-auto_merge:
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  auto_merge: true
+  update_external_dependencies: true

--- a/govuk_test.gemspec
+++ b/govuk_test.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop-govuk", "4.16.1"
+  spec.add_development_dependency "simplecov"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4.


### PR DESCRIPTION
- Adds code coverage checker
- Upgrades to govuk-dependabot-merger V2
- Enables auto-merge of external dependencies

Trello: https://trello.com/c/iC9shJG4/3479-roll-out-govuk-dependabot-merger-v2-across-select-repositories