### PR TITLE
Configure CI workflow to handle concurrent releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   codeql-sast:
     name: CodeQL SAST scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 4.1.2
+
+* Configure CI workflow to handle concurrent releases ([#112](https://github.com/alphagov/govuk_test/pull/112))
+
 ## 4.1.1
 
 * Ratchet version number to add Github Actions Linting checks

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "4.1.1".freeze
+  VERSION = "4.1.2".freeze
 end


### PR DESCRIPTION
**As a** platform engineer
**I want** our deployment process for our app repos to handle concurrent releases
**so that** we avoid issues with incorrect ordering of releases

https://github.com/alphagov/govuk-infrastructure/issues/2123