### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
+---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: "github-actions"
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 4.1.3
+* Set dependency cooldowns in Dependabot
+
 ## 4.1.2
 
 * Configure CI workflow to handle concurrent releases ([#112](https://github.com/alphagov/govuk_test/pull/112))

--- a/lib/govuk_test/version.rb
+++ b/lib/govuk_test/version.rb
@@ -1,3 +1,3 @@
 module GovukTest
-  VERSION = "4.1.2".freeze
+  VERSION = "4.1.3".freeze
 end


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
